### PR TITLE
refacto(PDBList): from FTP to HTTPS

### DIFF
--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -125,9 +125,9 @@ class PDBServer:
 
 
 SERVERS = [
-    PDBServer("ftp://ftp.rcsb.org/pub/pdb/"),
-    PDBServer("ftp://ftp.ebi.ac.uk/pub/databases/pdb/"),
-    PDBServer("ftp://ftp.pdbj.org/pub/pdb/"),
+    PDBServer("https://files.rcsb.org/pub/pdb/"),
+    PDBServer("https://ftp.ebi.ac.uk/pub/databases/pdb/"),
+    PDBServer("https://ftp.pdbj.org/pub/pdb/"),
 ]
 
 

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -116,6 +116,13 @@ class PDBServer:
                 r"OBSLTE\s+\d{2}-\w{3}-\d{2}\s+(\w{4})", handle.read().decode()
             )
 
+    @functools.cached_property
+    def sequences(self):
+        """Retrieve and save a (big) file containing all the sequences of PDB entries."""
+        url = urljoin(self.pdb_dir_url, "derived_data/pdb_seqres.txt")
+        with contextlib.closing(urlopen(url)) as handle:
+            return handle.read()
+
 
 SERVERS = [
     PDBServer("ftp://ftp.rcsb.org/pub/pdb/"),
@@ -598,8 +605,8 @@ class PDBList:
         """Retrieve and save a (big) file containing all the sequences of PDB entries."""
         if self._verbose:
             print("Retrieving sequence file (takes over 110 MB).")
-        url = urljoin(self.pdb_server.pdb_dir_url, "derived_data/pdb_seqres.txt")
-        urlretrieve(url, savefile)
+        with open(savefile, "wb+") as steam:
+            steam.write(self.pdb_server.sequences)
 
 
 @functools.lru_cache(maxsize=None)

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -86,6 +86,36 @@ class PDBServer:
                 latests[latest] = latest_regex.findall(handle.read().decode())
         return (latests["added"], latests["modified"], latests["obsolete"])
 
+    @functools.cached_property
+    def obsoletes(self) -> list[str]:
+        """Return a list of all obsolete entries ever in the PDB.
+
+        Returns a list of all obsolete pdb codes that have ever been
+        in the PDB.
+
+        Gets and parses the file from the PDB server in the format
+        (the first pdb_code column is the one used). The file looks
+        like this::
+
+             LIST OF OBSOLETE COORDINATE ENTRIES AND SUCCESSORS
+            OBSLTE    31-JUL-94 116L     216L
+            ...
+            OBSLTE    29-JAN-96 1HFT     2HFT
+            OBSLTE    21-SEP-06 1HFV     2J5X
+            OBSLTE    21-NOV-03 1HG6
+            OBSLTE    18-JUL-84 1HHB     2HHB 3HHB
+            OBSLTE    08-NOV-96 1HID     2HID
+            OBSLTE    01-APR-97 1HIU     2HIU
+            OBSLTE    14-JAN-04 1HKE     1UUZ
+            ...
+
+        """
+        url = urljoin(self.pdb_dir_url, "data/status/obsolete.dat")
+        with contextlib.closing(urlopen(url)) as handle:
+            return re.findall(
+                r"OBSLTE\s+\d{2}-\w{3}-\d{2}\s+(\w{4})", handle.read().decode()
+            )
+
 
 SERVERS = [
     PDBServer("ftp://ftp.rcsb.org/pub/pdb/"),
@@ -171,42 +201,6 @@ class PDBList:
             )
             return "mmCif"
         return file_format
-
-    def get_all_obsolete(self):
-        """Return a list of all obsolete entries ever in the PDB.
-
-        Returns a list of all obsolete pdb codes that have ever been
-        in the PDB.
-
-        Gets and parses the file from the PDB server in the format
-        (the first pdb_code column is the one used). The file looks
-        like this::
-
-             LIST OF OBSOLETE COORDINATE ENTRIES AND SUCCESSORS
-            OBSLTE    31-JUL-94 116L     216L
-            ...
-            OBSLTE    29-JAN-96 1HFT     2HFT
-            OBSLTE    21-SEP-06 1HFV     2J5X
-            OBSLTE    21-NOV-03 1HG6
-            OBSLTE    18-JUL-84 1HHB     2HHB 3HHB
-            OBSLTE    08-NOV-96 1HID     2HID
-            OBSLTE    01-APR-97 1HIU     2HIU
-            OBSLTE    14-JAN-04 1HKE     1UUZ
-            ...
-
-        """
-        url = urljoin(self.pdb_server.pdb_dir_url, "data/status/obsolete.dat")
-        with contextlib.closing(urlopen(url)) as handle:
-            # Extract pdb codes. Could use a list comprehension, but I want
-            # to include an assert to check for mis-reading the data.
-            obsolete = []
-            for line in handle:
-                if not line.startswith(b"OBSLTE "):
-                    continue
-                pdb = line.split()[2]
-                assert len(pdb) == 4
-                obsolete.append(pdb.decode())
-        return obsolete
 
     def retrieve_pdb_file(
         self, pdb_code, obsolete=False, pdir=None, file_format=None, overwrite=False
@@ -592,14 +586,13 @@ class PDBList:
         """
         # Deprecation warning
         file_format = self._print_default_format_warning(file_format)
-        entries = self.get_all_obsolete()
-        for pdb_code in entries:
+        for pdb_code in self.pdb_server.obsoletes:
             self.retrieve_pdb_file(pdb_code, obsolete=True, file_format=file_format)
 
         # Write the list
         if listfile:
             with open(listfile, "w") as outfile:
-                outfile.writelines(x + "\n" for x in entries)
+                outfile.writelines("\n".join(self.pdb_server.obsoletes))
 
     def get_seqres_file(self, savefile="pdb_seqres.txt"):
         """Retrieve and save a (big) file containing all the sequences of PDB entries."""

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -37,7 +37,6 @@
 
 from __future__ import annotations
 
-import collections
 import contextlib
 import dataclasses
 import ftplib
@@ -49,12 +48,11 @@ import shutil
 import socket
 import sys
 import time
-
-from urllib.request import urlopen
-from urllib.request import urlretrieve
-from urllib.request import urlcleanup
 from urllib.parse import urljoin
 from urllib.parse import urlunsplit
+from urllib.request import urlcleanup
+from urllib.request import urlopen
+from urllib.request import urlretrieve
 
 from Bio.PDB.PDBExceptions import PDBException
 

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -126,6 +126,7 @@ class PDBServer:
 
 SERVERS = [
     PDBServer("https://files.rcsb.org/pub/pdb/"),
+    PDBServer("https://s3.rcsb.org/pub/pdb/"),
     PDBServer("https://ftp.ebi.ac.uk/pub/databases/pdb/"),
     PDBServer("https://ftp.pdbj.org/pub/pdb/"),
 ]

--- a/Tests/test_PDBList.py
+++ b/Tests/test_PDBList.py
@@ -201,6 +201,10 @@ class TestPDBServer(unittest.TestCase):
         """Tests the Bio.PDB.PDBList.entries method."""
         self.assertGreater(len(get_fastest_server().obsoletes), 4300)
 
+    def test_sequences(self):
+        """Tests the Bio.PDB.PDBList.sequences method."""
+        self.assertIsNotNone(get_fastest_server().sequences)
+
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)

--- a/Tests/test_PDBList.py
+++ b/Tests/test_PDBList.py
@@ -28,7 +28,7 @@ class TestPBDListGetList(unittest.TestCase):
         """Tests the Bio.PDB.PDBList.get_recent_changes method."""
         # obsolete_pdb declared to prevent from creating the "obsolete" directory
         pdblist = PDBList(obsolete_pdb="unimportant")
-        url = urljoin(pdblist.pdb_server, "data/status/latest/added.pdb")
+        url = urljoin(pdblist.pdb_server.pdb_dir_url, "data/status/latest/added.pdb")
         entries = pdblist.get_status_list(url)
         self.assertIsNotNone(entries)
 

--- a/Tests/test_PDBList.py
+++ b/Tests/test_PDBList.py
@@ -42,15 +42,6 @@ class TestPBDListGetList(unittest.TestCase):
         # was exceeded
         self.assertGreater(len(entries), 3000)
 
-    def test_get_all_assemblies(self):
-        """Tests the Bio.PDB.PDBList.get_all_assemblies method."""
-        # obsolete_pdb declared to prevent from creating the "obsolete" directory
-        pdblist = PDBList(obsolete_pdb="unimportant")
-        entries = pdblist.get_all_assemblies()
-        # As number of obsolete entries constantly grow, test checks if a certain number
-        # was exceeded
-        self.assertGreater(len(entries), 100000)
-
 
 class TestPDBListGetStructure(unittest.TestCase):
     """Test methods responsible for getting structures."""
@@ -140,6 +131,16 @@ class TestPDBListGetStructure(unittest.TestCase):
         structure = "127d"
         self.check(structure, os.path.join("a", f"{structure}.cif"), "mmCif", pdir="a")
         self.check(structure, os.path.join("b", f"{structure}.cif"), "mmCif", pdir="b")
+
+    def test_download_assemblies(self):
+        """Tests the Bio.PDB.PDBList.download_assemblies method."""
+        structure = "127d"
+        with self.make_temp_directory(os.getcwd()) as tmp:
+            pdblist = PDBList(pdb=tmp)
+            pdblist.download_assemblies(
+                pdb_code=structure, file_format="mmCif", overwrite=False
+            )
+            self.assertTrue(os.path.isfile(os.path.join(tmp, "27/127d-assembly1.cif")))
 
 
 class TestPDBListGetAssembly(unittest.TestCase):

--- a/Tests/test_PDBList.py
+++ b/Tests/test_PDBList.py
@@ -15,6 +15,7 @@ from urllib.parse import urljoin
 
 # We want to test this module:
 from Bio.PDB.PDBList import PDBList
+from Bio.PDB.PDBList import get_fastest_server
 
 import requires_internet
 
@@ -31,15 +32,6 @@ class TestPBDListGetList(unittest.TestCase):
         url = urljoin(pdblist.pdb_server.pdb_dir_url, "data/status/latest/added.pdb")
         entries = pdblist.get_status_list(url)
         self.assertIsNotNone(entries)
-
-    def test_get_all_entries(self):
-        """Tests the Bio.PDB.PDBList.get_all_entries method."""
-        # obsolete_pdb declared to prevent from creating the "obsolete" directory
-        pdblist = PDBList(obsolete_pdb="unimportant")
-        entries = pdblist.get_all_entries()
-        # As number of entries constantly grow, test checks if a certain number was
-        # exceeded
-        self.assertGreater(len(entries), 100000)
 
     def test_get_all_obsolete(self):
         """Tests the Bio.PDB.PDBList.get_all_obsolete method."""
@@ -212,6 +204,14 @@ class TestPDBListGetAssembly(unittest.TestCase):
             "mmCif",
             pdir="b",
         )
+
+
+class TestPDBServer(unittest.TestCase):
+    def test_get_all_entries(self):
+        """Tests the Bio.PDB.PDBList.entries method."""
+        # As number of entries constantly grow,
+        # test checks if a certain number was exceeded
+        self.assertGreater(len(get_fastest_server().entries), 190000)
 
 
 if __name__ == "__main__":

--- a/Tests/test_PDBList.py
+++ b/Tests/test_PDBList.py
@@ -22,19 +22,6 @@ import requires_internet
 requires_internet.check()
 
 
-class TestPBDListGetList(unittest.TestCase):
-    """Test methods responsible for getting lists of entries."""
-
-    def test_get_all_obsolete(self):
-        """Tests the Bio.PDB.PDBList.get_all_obsolete method."""
-        # obsolete_pdb declared to prevent from creating the "obsolete" directory
-        pdblist = PDBList(obsolete_pdb="unimportant")
-        entries = pdblist.get_all_obsolete()
-        # As number of obsolete entries constantly grow, test checks if a certain number
-        # was exceeded
-        self.assertGreater(len(entries), 3000)
-
-
 class TestPDBListGetStructure(unittest.TestCase):
     """Test methods responsible for getting structures."""
 
@@ -209,6 +196,10 @@ class TestPDBServer(unittest.TestCase):
     def test_latests(self):
         """Tests the Bio.PDB.PDBList.latests method."""
         self.assertEqual(len(get_fastest_server().latests), 3)
+
+    def test_obsoletes(self):
+        """Tests the Bio.PDB.PDBList.entries method."""
+        self.assertGreater(len(get_fastest_server().obsoletes), 4300)
 
 
 if __name__ == "__main__":

--- a/Tests/test_PDBList.py
+++ b/Tests/test_PDBList.py
@@ -25,14 +25,6 @@ requires_internet.check()
 class TestPBDListGetList(unittest.TestCase):
     """Test methods responsible for getting lists of entries."""
 
-    def test_get_recent_changes(self):
-        """Tests the Bio.PDB.PDBList.get_recent_changes method."""
-        # obsolete_pdb declared to prevent from creating the "obsolete" directory
-        pdblist = PDBList(obsolete_pdb="unimportant")
-        url = urljoin(pdblist.pdb_server.pdb_dir_url, "data/status/latest/added.pdb")
-        entries = pdblist.get_status_list(url)
-        self.assertIsNotNone(entries)
-
     def test_get_all_obsolete(self):
         """Tests the Bio.PDB.PDBList.get_all_obsolete method."""
         # obsolete_pdb declared to prevent from creating the "obsolete" directory
@@ -213,6 +205,10 @@ class TestPDBServer(unittest.TestCase):
         # As number of entries constantly grow,
         # test checks if a certain number was exceeded
         self.assertGreater(len(get_fastest_server().entries), 190000)
+
+    def test_latests(self):
+        """Tests the Bio.PDB.PDBList.latests method."""
+        self.assertEqual(len(get_fastest_server().latests), 3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Following the work on https://github.com/biopython/biopython/pull/4012.

Switching from FTP to HTTPS.

I did not touch the code around `retrieve_pdb_file` yet as it deserves dedicated refactoring.

Review commit by commit is advised :v: 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [ ] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [ ] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #...
